### PR TITLE
feat: update MenuDropdown to use 'div' as Menu component

### DIFF
--- a/src/app/components/MenuDropdown/MenuDropdown.tsx
+++ b/src/app/components/MenuDropdown/MenuDropdown.tsx
@@ -24,7 +24,7 @@ const links = [
 export default function MenuDropdown({ image }: NavbarProps) {
   return (
     <div>
-      <Menu>
+      <Menu as='div'>
         <MenuButton className="btn btn-circle avatar">
           <div className="w-10 rounded-full">
             <Image


### PR DESCRIPTION
fix error from vercel deployment as passing props to a fragment error. 