### PR TITLE
fix: Incorrect quantity for months with 5 weeks

### DIFF
--- a/src/app/components/AutoBillCard/AutoBillCard.tsx
+++ b/src/app/components/AutoBillCard/AutoBillCard.tsx
@@ -19,7 +19,6 @@ interface BillCardsProps {
   unitPrice: number;
   billNumber: number;
   phone: string;
-  quantity: number;
 }
 
 export default function AutoBillCard(props: BillCardsProps) {
@@ -75,7 +74,6 @@ export default function AutoBillCard(props: BillCardsProps) {
             unitPrice={props.unitPrice}
             billNumber={props.billNumber}
             setShowModal={setShowModal}
-            quantity={props.quantity}
             phone={props.phone} />
         }</Modal>
       <Modal

--- a/src/app/components/AutoBillViewModal/AutoBillViewModal.tsx
+++ b/src/app/components/AutoBillViewModal/AutoBillViewModal.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@/app/core/utils/Button";
 import { errorToastHandler, successToastHandler } from "@/app/core/utils/toastHandler";
+import weekDayCounter from "@/app/core/utils/weekDayCounter";
 import { api } from '@/trpc/react';
 import { useRouter } from "next/navigation";
 
@@ -12,7 +13,6 @@ interface AutoBillViewModalProps {
   description: string;
   unitPrice: number;
   billNumber: number;
-  quantity: number;
   phone: string;
   setShowModal: (value: boolean) => void
 }
@@ -24,7 +24,6 @@ export default function AutoBillViewModal(props: AutoBillViewModalProps) {
   const description = props.description;
   const unitPrice = props.unitPrice;
   const billNumber = props.billNumber;
-  const quantity = props.quantity;
   const phone = props.phone;
   const numMonth: number = new Date().getMonth() - 1;
   const createBill = api.bill.createBill.useMutation()
@@ -34,6 +33,8 @@ export default function AutoBillViewModal(props: AutoBillViewModalProps) {
   }
 
   const handleCreateAutoBill = () => {
+    const weekCounter = weekDayCounter({ numMonth })
+    const quantity = weekCounter.length;
     const amount = Number(quantity * unitPrice);
 
     createBill.mutate({

--- a/src/app/components/AutoCardContainer/AutoCardContainer.tsx
+++ b/src/app/components/AutoCardContainer/AutoCardContainer.tsx
@@ -31,7 +31,7 @@ export default async function AutoCardContainer({ query }: { query: string }) {
               unitPrice={bill.UnitPrice}
               billNumber={bill.billNumber}
               phone={bill.phone}
-              quantity={bill.quantity} />
+            />
           </Suspense>
         )
       })}


### PR DESCRIPTION
Correct calculation of weeks for months with 5 weeks. Now the calculation is correct and quantity should not display 4 when is a month with 5 weeks. 

close #25 